### PR TITLE
Componente Request creado

### DIFF
--- a/src/lib/request/request.ts
+++ b/src/lib/request/request.ts
@@ -1,0 +1,151 @@
+export enum HttpRequestType {
+    GET = "GET",
+    POST = "POST",
+    PUT = "PUT",
+    DELETE = "DELETE"
+}
+
+const BASE_URL = "http://localhost:8080"
+
+const DEBUG : boolean = true
+
+export class HttpError {
+    code: number;
+    message: string;
+
+    constructor(code: number, message: string) {
+        this.code = code
+        this.message = message
+    }
+}
+
+export class ProxyError {
+    code: number;
+    message: string;
+    url: string;
+
+    constructor(code: number, message: string, url: string) {
+        this.code = code
+        this.message = message
+        this.url = url
+    }
+}
+
+export async function request(
+    type: HttpRequestType, //GET, POST, PUT, DELETE
+    path: string, //Ruta dentro de la API
+    args: Map<string, string> | null = null, //Lista de argumentos a pasar en la URL
+    body: string | FormData | null = null, //Cuerpo de la solicitud
+    baseUrl : string = BASE_URL, //Ruta base de la API, es concatenada antes de path
+    useAuth : boolean = true //Autenticar al usuario al realizar la solicitud
+) : Promise<HttpError | any> {
+    let headers : any = {
+        'Content-Type': 'application/json'
+    }
+
+    if (useAuth) {
+        headers["Authorization"] = "Bearer " +  localStorage.getItem("token")
+    }
+
+    let data : RequestInit = {
+        method: type,
+        headers: headers,
+        mode: 'cors',
+        credentials: "include"
+    }
+
+    let argUrl = "?"
+
+    if (args !== null) {
+        args.forEach((val, key) => {
+            argUrl += `${key}=${val}&`
+        });
+    }
+
+    if (body !== null) {
+        data["body"] = body
+    }
+
+    argUrl = argUrl.substring(0, argUrl.length - 1)
+
+    let url = `${baseUrl}/${path}${argUrl}`
+
+    url = encodeURI(url)
+
+    
+    
+    let response = await fetch(url, data)
+    .catch((error) => {
+        if (DEBUG) {
+            console.warn(`Using proxy for request: ${url}`);
+        } else {
+            throw new HttpError(-1, "No se pudo realizar la solicitud");
+            
+        }
+    });
+
+    if (DEBUG && (!(response instanceof Response) || response.status === 404)) {
+        const dummy_url = `proxy/${path}.txt`
+        const dummy = await fetch(dummy_url)
+        const dummy_txt = await dummy.text()
+
+        const dummy_regex : RegExp = /REQUEST TYPE\s+(\w+)\s+REQUEST ARGS\s+([\s\S]*?)REQUEST BODY\s+({[\s\S]*?})\s+RESPONSE TYPE\s+(\w+)\s+RESPONSE BODY\s+({[\s\S]*})/
+    
+        let dummy_parts = dummy_regex.exec(dummy_txt)
+
+        if (dummy_parts === null) throw new ProxyError(0, "El endpoint dummy tiene un formato incorrecto", dummy_url);      
+
+        let dummy_req_type = dummy_parts[1];
+        if (!["GET","POST","PUT","DELETE"].includes(dummy_req_type))
+            throw new ProxyError(1, `Método HTTP no soportado: ${dummy_req_type}`, dummy_url)
+        
+        let dummy_req_args = dummy_parts[2];
+        let req_args_regex : RegExp = /^\s*(?:[^\s]+\s*\:\s*[^\s]+\s*\n+)*$/
+        if (!req_args_regex.test(dummy_req_args)) {
+            throw new ProxyError(2, `Argumentos de solicitud no válidos`, dummy_url)
+        }
+
+        let dummy_req_body = dummy_parts[3];
+        try {
+            JSON.parse(dummy_req_body)
+        } catch (e) {
+            throw new ProxyError(3, `Solicitud JSON no válida`, dummy_url)
+        }
+
+        let dummy_res_type = dummy_parts[4];
+        if (!["TEXT","JSON","BLOB"].includes(dummy_res_type))
+            throw new ProxyError(4, `Tipo de contenido de respuesta HTTP no soportado: ${dummy_res_type}`, dummy_url)
+        
+        let dummy_res_body = dummy_parts[5];
+        switch (dummy_res_type) {
+            case "TEXT":
+                return dummy_res_body        
+            case "JSON":
+                try {
+                    return JSON.parse(dummy_res_body)
+                } catch (e) {
+                    throw new ProxyError(5, `Respuesta JSON no válida`, dummy_url)
+                }
+            case "BLOB":
+                return dummy_res_body  
+            default:
+                break;
+        }        
+    }
+
+    response = <Response>response;
+
+    if (response.status === 200) {
+        let contentType = response.headers.get("content-type")
+        switch (contentType) {
+            case "text/plain":
+                return await response.text()
+            case "application/json":
+                return await response.json()
+            default:
+                return await response.blob()
+        }
+    }
+
+    return <HttpError> await response.json();
+}

--- a/src/lib/services/TestService.ts
+++ b/src/lib/services/TestService.ts
@@ -1,0 +1,8 @@
+import { HttpRequestType, request } from "$lib/request/request";
+
+export const TestService = {
+    endpoint: async () => {
+        let response = await request(HttpRequestType.GET, "path/endpoint");
+        return response;
+    }
+}

--- a/src/routes/Link2/+page.svelte
+++ b/src/routes/Link2/+page.svelte
@@ -1,1 +1,20 @@
-<p>Contenido de la página 2</p>
+<script lang="ts">
+	import { TestService } from "$lib/services/TestService";
+	import { onMount } from "svelte";
+
+    let resp;
+    let estado = "";
+
+    onMount(async () => {
+        resp = await TestService.endpoint();
+        console.log(resp);
+        estado = "Respuesta recibida: " + JSON.stringify(resp);
+    })
+</script>
+
+<h2>Solicitud de ejemplo</h2>
+
+<p>{estado}</p>
+
+
+

--- a/static/proxy/path/endpoint.txt
+++ b/static/proxy/path/endpoint.txt
@@ -1,0 +1,38 @@
+REQUEST TYPE GET
+
+REQUEST ARGS
+
+arg1 : val1
+arg2 : val2
+
+REQUEST BODY
+
+{
+    "key1": "val1",
+    "key2": {
+        "key2_1": 1.5,
+        "key2_2": null
+    },
+    "key3": [
+        "a",
+        "b",
+        "c"
+    ]
+}
+
+RESPONSE TYPE JSON
+
+RESPONSE BODY
+
+{
+    "key1": "val1",
+    "key2": {
+        "key2_1": 1.5,
+        "key2_2": null
+    },
+    "key3": [
+        "a",
+        "b",
+        "c"
+    ]
+}


### PR DESCRIPTION
Mecanismo para documentación de endpoints en el front-end creado.

Al crear los _Services_ del front-end, se debe usar la función `request()`. Esta funciona como wrapper de `fetch()`, incorporando la obligatoriedad de definir en un archivo `.txt` cómo deben ser los endpoints, tanto la solicitud como la respuesta. 

Se incorpora:
* Ejemplo de endpoint dummy (`/static/proxy/path/endpoint.txt`)
* Ejemplo de service (`/src/lib/services/TestService.ts`)
* Ejemplo de llamada a service (`/src/routes/Link2`)

`request()` utiliza el endpoint dummy cuando se encuentra en modo DEBUG y no encuentra el endpoint verdadero en el back-end. En este caso, valida la estructura del endpoint dummy y, de ser válida, devuelve lo que esta indica.